### PR TITLE
Simplify

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(name: "Provident",
                           .library(name: "Provident", targets: ["Provident"])
                       ],
                       dependencies: [
-                          ],
+                      ],
                       targets: [
                           .target(name: "Provident",
                                   path: "Source"),

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(name: "Provident",
                           .library(name: "Provident", targets: ["Provident"])
                       ],
                       dependencies: [
-                      ],
+                          ],
                       targets: [
                           .target(name: "Provident",
                                   path: "Source"),

--- a/Provident.xcodeproj/project.pbxproj
+++ b/Provident.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		65ED276D227DAAF100F0A545 /* TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65ED276B227DAAF100F0A545 /* TestData.swift */; };
 		65ED276E227DAAF100F0A545 /* TestResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65ED276C227DAAF100F0A545 /* TestResolver.swift */; };
 		F482D344244C698500F13FB1 /* RegistryVoidContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482D343244C698500F13FB1 /* RegistryVoidContextTests.swift */; };
+		F482D346244C6E8300F13FB1 /* RegistryAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482D345244C6E8300F13FB1 /* RegistryAPITests.swift */; };
+		F482D348244C978C00F13FB1 /* UIViewController+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482D347244C978C00F13FB1 /* UIViewController+Testing.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +51,8 @@
 		65ED276B227DAAF100F0A545 /* TestData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestData.swift; sourceTree = "<group>"; };
 		65ED276C227DAAF100F0A545 /* TestResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestResolver.swift; sourceTree = "<group>"; };
 		F482D343244C698500F13FB1 /* RegistryVoidContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistryVoidContextTests.swift; sourceTree = "<group>"; };
+		F482D345244C6E8300F13FB1 /* RegistryAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistryAPITests.swift; sourceTree = "<group>"; };
+		F482D347244C978C00F13FB1 /* UIViewController+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Testing.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +110,7 @@
 			children = (
 				65C139AC227DA8AA005BC016 /* Info.plist */,
 				65ED276B227DAAF100F0A545 /* TestData.swift */,
+				F482D347244C978C00F13FB1 /* UIViewController+Testing.swift */,
 				65ED2765227DAAAC00F0A545 /* Registry */,
 				65ED2766227DAAC100F0A545 /* Resolver */,
 			);
@@ -150,6 +155,7 @@
 			isa = PBXGroup;
 			children = (
 				65ED2768227DAAE400F0A545 /* RegistrarTests.swift */,
+				F482D345244C6E8300F13FB1 /* RegistryAPITests.swift */,
 				65ED2767227DAAE400F0A545 /* RegistryTests.swift */,
 				F482D343244C698500F13FB1 /* RegistryVoidContextTests.swift */,
 			);
@@ -289,6 +295,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				65ED276A227DAAE400F0A545 /* RegistrarTests.swift in Sources */,
+				F482D348244C978C00F13FB1 /* UIViewController+Testing.swift in Sources */,
+				F482D346244C6E8300F13FB1 /* RegistryAPITests.swift in Sources */,
 				65ED2769227DAAE400F0A545 /* RegistryTests.swift in Sources */,
 				65ED276E227DAAF100F0A545 /* TestResolver.swift in Sources */,
 				F482D344244C698500F13FB1 /* RegistryVoidContextTests.swift in Sources */,

--- a/Provident.xcodeproj/project.pbxproj
+++ b/Provident.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		F482D344244C698500F13FB1 /* RegistryVoidContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482D343244C698500F13FB1 /* RegistryVoidContextTests.swift */; };
 		F482D346244C6E8300F13FB1 /* RegistryAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482D345244C6E8300F13FB1 /* RegistryAPITests.swift */; };
 		F482D348244C978C00F13FB1 /* UIViewController+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482D347244C978C00F13FB1 /* UIViewController+Testing.swift */; };
+		F4CCA28B247C06E90076D27A /* SingleViewControllerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CCA28A247C06E90076D27A /* SingleViewControllerProvider.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +54,7 @@
 		F482D343244C698500F13FB1 /* RegistryVoidContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistryVoidContextTests.swift; sourceTree = "<group>"; };
 		F482D345244C6E8300F13FB1 /* RegistryAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistryAPITests.swift; sourceTree = "<group>"; };
 		F482D347244C978C00F13FB1 /* UIViewController+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Testing.swift"; sourceTree = "<group>"; };
+		F4CCA28A247C06E90076D27A /* SingleViewControllerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleViewControllerProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,6 +122,7 @@
 		65ED2755227DA9A700F0A545 /* ViewControllerProvider */ = {
 			isa = PBXGroup;
 			children = (
+				F4CCA28A247C06E90076D27A /* SingleViewControllerProvider.swift */,
 				65ED2763227DAA6700F0A545 /* ViewControllerProvider.swift */,
 			);
 			path = ViewControllerProvider;
@@ -287,6 +290,7 @@
 				65ED2764227DAA6700F0A545 /* ViewControllerProvider.swift in Sources */,
 				65ED275B227DAA4A00F0A545 /* Registrar.swift in Sources */,
 				65ED275C227DAA4A00F0A545 /* Registry.swift in Sources */,
+				F4CCA28B247C06E90076D27A /* SingleViewControllerProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Provident.xcodeproj/project.pbxproj
+++ b/Provident.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		65ED276A227DAAE400F0A545 /* RegistrarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65ED2768227DAAE400F0A545 /* RegistrarTests.swift */; };
 		65ED276D227DAAF100F0A545 /* TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65ED276B227DAAF100F0A545 /* TestData.swift */; };
 		65ED276E227DAAF100F0A545 /* TestResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65ED276C227DAAF100F0A545 /* TestResolver.swift */; };
+		F482D344244C698500F13FB1 /* RegistryVoidContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482D343244C698500F13FB1 /* RegistryVoidContextTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +48,7 @@
 		65ED2768227DAAE400F0A545 /* RegistrarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrarTests.swift; sourceTree = "<group>"; };
 		65ED276B227DAAF100F0A545 /* TestData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestData.swift; sourceTree = "<group>"; };
 		65ED276C227DAAF100F0A545 /* TestResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestResolver.swift; sourceTree = "<group>"; };
+		F482D343244C698500F13FB1 /* RegistryVoidContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistryVoidContextTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,12 +91,12 @@
 		65C1399E227DA8AA005BC016 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				65C1399F227DA8AA005BC016 /* Provident.h */,
+				65C139A0227DA8AA005BC016 /* Info.plist */,
 				65ED2758227DAA2B00F0A545 /* Registry */,
 				65ED2756227DA9D600F0A545 /* Resolver */,
 				65ED2757227DA9E800F0A545 /* ServiceProvider */,
 				65ED2755227DA9A700F0A545 /* ViewControllerProvider */,
-				65C1399F227DA8AA005BC016 /* Provident.h */,
-				65C139A0227DA8AA005BC016 /* Info.plist */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -102,10 +104,10 @@
 		65C139A9227DA8AA005BC016 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				65C139AC227DA8AA005BC016 /* Info.plist */,
+				65ED276B227DAAF100F0A545 /* TestData.swift */,
 				65ED2765227DAAAC00F0A545 /* Registry */,
 				65ED2766227DAAC100F0A545 /* Resolver */,
-				65ED276B227DAAF100F0A545 /* TestData.swift */,
-				65C139AC227DA8AA005BC016 /* Info.plist */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -149,6 +151,7 @@
 			children = (
 				65ED2768227DAAE400F0A545 /* RegistrarTests.swift */,
 				65ED2767227DAAE400F0A545 /* RegistryTests.swift */,
+				F482D343244C698500F13FB1 /* RegistryVoidContextTests.swift */,
 			);
 			path = Registry;
 			sourceTree = "<group>";
@@ -227,7 +230,7 @@
 					};
 					65C139A4227DA8AA005BC016 = {
 						CreatedOnToolsVersion = 10.2.1;
-						LastSwiftMigration = 1120;
+						LastSwiftMigration = 1140;
 					};
 				};
 			};
@@ -288,6 +291,7 @@
 				65ED276A227DAAE400F0A545 /* RegistrarTests.swift in Sources */,
 				65ED2769227DAAE400F0A545 /* RegistryTests.swift in Sources */,
 				65ED276E227DAAF100F0A545 /* TestResolver.swift in Sources */,
+				F482D344244C698500F13FB1 /* RegistryVoidContextTests.swift in Sources */,
 				65ED276D227DAAF100F0A545 /* TestData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/Registry/Registrar.swift
+++ b/Source/Registry/Registrar.swift
@@ -21,10 +21,6 @@ public class Registrar<T, C> {
         self.registry = registry
     }
 
-    deinit {
-        unregisterViewControllerProviders()
-    }
-
     public func resolve(serviceProviderFunctions: [ServiceProviderFunction],
                         viewControllerProviderFunctions: [ViewControllerProviderFunction],
                         launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) {
@@ -54,12 +50,5 @@ public class Registrar<T, C> {
             viewControllerProvider.configure(with: serviceProviders)
             viewControllerProviders.append(viewControllerProvider)
         }
-    }
-
-    internal func unregisterViewControllerProviders() {
-        for viewControllerProvider in viewControllerProviders {
-            viewControllerProvider.unregister(from: registry)
-        }
-        viewControllerProviders.removeAll()
     }
 }

--- a/Source/Registry/Registrar.swift
+++ b/Source/Registry/Registrar.swift
@@ -21,6 +21,10 @@ public class Registrar<T, C> {
         self.registry = registry
     }
 
+    deinit {
+        registry.reset()
+    }
+    
     public func resolve(serviceProviderFunctions: [ServiceProviderFunction],
                         viewControllerProviderFunctions: [ViewControllerProviderFunction],
                         launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) {

--- a/Source/Registry/Registrar.swift
+++ b/Source/Registry/Registrar.swift
@@ -24,7 +24,7 @@ public class Registrar<T, C> {
     deinit {
         registry.reset()
     }
-    
+
     public func resolve(serviceProviderFunctions: [ServiceProviderFunction],
                         viewControllerProviderFunctions: [ViewControllerProviderFunction],
                         launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) {

--- a/Source/Registry/Registry.swift
+++ b/Source/Registry/Registry.swift
@@ -30,6 +30,10 @@ open class Registry<T, C> {
         functions.append(registryFunction)
     }
 
+    func reset() {
+        functions.removeAll()
+    }
+
     public func createViewController(from token: T, context: C) -> UIViewController? {
         for function in functions {
             if let result = function(token, context) {

--- a/Source/Registry/Registry.swift
+++ b/Source/Registry/Registry.swift
@@ -22,29 +22,16 @@ import UIKit
 open class Registry<T, C> {
     typealias RegistryFunction = (T, C) -> UIViewController?
 
-    private var orderedFunctionUUIDs = [UUID]()
-    private var orderedFunctions = [RegistryFunction]()
+    private var functions = [RegistryFunction]()
 
     public init() {}
 
-    func add(registryFunction: @escaping RegistryFunction) -> UUID {
-        let uuid = UUID()
-        orderedFunctionUUIDs.append(uuid)
-        orderedFunctions.append(registryFunction)
-        return uuid
-    }
-
-    @discardableResult
-    func removeRegistryFunction(uuid: UUID) -> Bool {
-        guard let index = orderedFunctionUUIDs.firstIndex(of: uuid) else { return false }
-
-        _ = orderedFunctionUUIDs.remove(at: index)
-        _ = orderedFunctions.remove(at: index)
-        return true
+    func add(registryFunction: @escaping RegistryFunction) {
+        functions.append(registryFunction)
     }
 
     public func createViewController(from token: T, context: C) -> UIViewController? {
-        for function in orderedFunctions {
+        for function in functions {
             if let result = function(token, context) {
                 return result
             }

--- a/Source/Registry/Registry.swift
+++ b/Source/Registry/Registry.swift
@@ -20,14 +20,14 @@ import UIKit
 /// VC for the same token, functions that register with a context will return first, and if there are still multiple,
 /// the function that was registered first will return first.
 open class Registry<T, C> {
-    public typealias RegistryFunction = (T, C) -> UIViewController?
+    typealias RegistryFunction = (T, C) -> UIViewController?
 
     private var orderedFunctionUUIDs = [UUID]()
     private var orderedFunctions = [RegistryFunction]()
 
     public init() {}
 
-    public func add(registryFunction: @escaping RegistryFunction) -> UUID {
+    func add(registryFunction: @escaping RegistryFunction) -> UUID {
         let uuid = UUID()
         orderedFunctionUUIDs.append(uuid)
         orderedFunctions.append(registryFunction)
@@ -35,7 +35,7 @@ open class Registry<T, C> {
     }
 
     @discardableResult
-    public func removeRegistryFunction(uuid: UUID) -> Bool {
+    func removeRegistryFunction(uuid: UUID) -> Bool {
         guard let index = orderedFunctionUUIDs.firstIndex(of: uuid) else { return false }
 
         _ = orderedFunctionUUIDs.remove(at: index)

--- a/Source/Resolver/Resolver.swift
+++ b/Source/Resolver/Resolver.swift
@@ -13,6 +13,6 @@ import UIKit
 /// the objc-runtime (currently not working as ViewControllerProvider is a swift class that uses generics).
 open class Resolver<T, C> {
     public init() {}
-    open func viewControllerProviderCreationFunctions() -> [() -> ViewControllerProvider<T, C>] { return [] }
-    open func serviceProviderCreationFunctions() -> [(ServiceProviderCreationContext) -> ServiceProvider] { return [] }
+    open func serviceProviderFunctions() -> [Registrar<T, C>.ServiceProviderFunction] { return [] }
+    open func viewControllerProviderFunctions() -> [Registrar<T, C>.ViewControllerProviderFunction] { return [] }
 }

--- a/Source/ViewControllerProvider/SingleViewControllerProvider.swift
+++ b/Source/ViewControllerProvider/SingleViewControllerProvider.swift
@@ -1,0 +1,22 @@
+//
+//  SingleViewControllerProvider.swift
+//  Provident
+//
+//  Created by Home on 25/05/2020.
+//  Copyright © 2020 Ceri Hughes. All rights reserved.
+//
+
+import UIKit
+
+open class SingleViewControllerProvider<T, C>: ViewControllerProvider<T, C> {
+    override public init() {}
+
+    override open func register(with registry: Registry<T, C>) {
+        registry.add(registryFunction: createViewController(token:context:))
+    }
+
+    open func createViewController(token: T, context: C) -> UIViewController? {
+        // OVERRIDE
+        return nil
+    }
+}

--- a/Source/ViewControllerProvider/ViewControllerProvider.swift
+++ b/Source/ViewControllerProvider/ViewControllerProvider.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Ceri Hughes. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 /// A class that provides a VC (or a number of VCs) for a given token by registering with a ViewControllerRegistry.
 open class ViewControllerProvider<T, C> {

--- a/Source/ViewControllerProvider/ViewControllerProvider.swift
+++ b/Source/ViewControllerProvider/ViewControllerProvider.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Ceri Hughes. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 /// A class that provides a VC (or a number of VCs) for a given token by registering with a ViewControllerRegistry.
 open class ViewControllerProvider<T, C> {

--- a/Source/ViewControllerProvider/ViewControllerProvider.swift
+++ b/Source/ViewControllerProvider/ViewControllerProvider.swift
@@ -10,8 +10,24 @@ import Foundation
 
 /// A class that provides a VC (or a number of VCs) for a given token by registering with a ViewControllerRegistry.
 open class ViewControllerProvider<T, C> {
+    private var uuid: UUID?
+
     public init() {}
-    open func register(with _: Registry<T, C>) {}
-    open func unregister(from _: Registry<T, C>) {}
+
+    func register(with registry: Registry<T, C>) {
+        uuid = registry.add(registryFunction: createViewController(token:context:))
+    }
+
+    func unregister(from registry: Registry<T, C>) {
+        guard let uuid = uuid else { return }
+
+        registry.removeRegistryFunction(uuid: uuid)
+    }
+
     open func configure(with _: [String: ServiceProvider]) {}
+
+    open func createViewController(token: T, context: C) -> UIViewController? {
+        // OVERRIDE
+        return nil
+    }
 }

--- a/Source/ViewControllerProvider/ViewControllerProvider.swift
+++ b/Source/ViewControllerProvider/ViewControllerProvider.swift
@@ -10,24 +10,7 @@ import UIKit
 
 /// A class that provides a VC (or a number of VCs) for a given token by registering with a ViewControllerRegistry.
 open class ViewControllerProvider<T, C> {
-    private var uuid: UUID?
-
     public init() {}
-
-    func register(with registry: Registry<T, C>) {
-        uuid = registry.add(registryFunction: createViewController(token:context:))
-    }
-
-    func unregister(from registry: Registry<T, C>) {
-        guard let uuid = uuid else { return }
-
-        registry.removeRegistryFunction(uuid: uuid)
-    }
-
+    open func register(with _: Registry<T, C>) {}
     open func configure(with _: [String: ServiceProvider]) {}
-
-    open func createViewController(token: T, context: C) -> UIViewController? {
-        // OVERRIDE
-        return nil
-    }
 }

--- a/Tests/Registry/RegistrarTests.swift
+++ b/Tests/Registry/RegistrarTests.swift
@@ -51,7 +51,7 @@ class RegistrarTests: XCTestCase {
         XCTAssertTrue(TestServiceProviderFactory.created)
     }
 
-    func testRegisterAndUnregisterViewControllerProviders() {
+    func testRegisterViewControllerProviders() {
         TestViewControllerProviderFactory.created = false
 
         XCTAssertEqual(registrar.viewControllerProviders.count, 0)
@@ -64,15 +64,6 @@ class RegistrarTests: XCTestCase {
             let testViewControllerProvider = viewControllerProvider as! TestViewControllerProvider
             XCTAssertTrue(testViewControllerProvider.registered)
             XCTAssertFalse(testViewControllerProvider.unregistered)
-        }
-
-        registrar.unregisterViewControllerProviders()
-        XCTAssertEqual(registrar.viewControllerProviders.count, 0)
-
-        for viewControllerProvider in registrar.viewControllerProviders {
-            let testViewControllerProvider = viewControllerProvider as! TestViewControllerProvider
-            XCTAssertTrue(testViewControllerProvider.registered)
-            XCTAssertTrue(testViewControllerProvider.unregistered)
         }
     }
 }

--- a/Tests/Registry/RegistrarTests.swift
+++ b/Tests/Registry/RegistrarTests.swift
@@ -22,10 +22,11 @@ class RegistrarTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        let testViewControllerProviderCreationFunctions: [() -> ViewControllerProvider<String, Void>] = [TestViewControllerProviderFactory.createViewControllerProvider]
-        let testServiceProviderCreationFunctions: [(ServiceProviderCreationContext) -> ServiceProvider] = [TestServiceProviderFactory.createServiceProvider]
-        resolver = TestResolver(testViewControllerProviderCreationFunctions: testViewControllerProviderCreationFunctions,
-                                testServiceProviderCreationFunctions: testServiceProviderCreationFunctions)
+
+        let testServiceProviderFunctions = [TestServiceProviderFactory.createServiceProvider]
+        let testViewControllerProviderFunctions = [TestViewControllerProviderFactory.createViewControllerProvider]
+        resolver = TestResolver(testServiceProviderFunctions: testServiceProviderFunctions,
+                                testViewControllerProviderFunctions: testViewControllerProviderFunctions)
         registry = Registry()
         registrar = Registrar(registry: registry)
     }
@@ -34,6 +35,7 @@ class RegistrarTests: XCTestCase {
         registrar = nil
         resolver = nil
         registry = nil
+
         super.tearDown()
     }
 
@@ -41,7 +43,7 @@ class RegistrarTests: XCTestCase {
         TestServiceProviderFactory.created = false
 
         XCTAssertEqual(registrar.serviceProviders.count, 0)
-        registrar.createServiceProviders(functions: resolver.serviceProviderCreationFunctions(), context: ServiceProviderCreationContextImplementation())
+        registrar.createServiceProviders(functions: resolver.serviceProviderFunctions(), context: ServiceProviderCreationContextImplementation())
 
         // Both factories create a service provider object with the same name, so we only get 1 object
         XCTAssertEqual(registrar.serviceProviders.count, 1)
@@ -53,7 +55,7 @@ class RegistrarTests: XCTestCase {
         TestViewControllerProviderFactory.created = false
 
         XCTAssertEqual(registrar.viewControllerProviders.count, 0)
-        registrar.registerViewControllerProviders(functions: resolver.viewControllerProviderCreationFunctions())
+        registrar.registerViewControllerProviders(functions: resolver.viewControllerProviderFunctions())
         XCTAssertEqual(registrar.viewControllerProviders.count, 1)
 
         XCTAssertTrue(TestViewControllerProviderFactory.created)

--- a/Tests/Registry/RegistryAPITests.swift
+++ b/Tests/Registry/RegistryAPITests.swift
@@ -1,0 +1,67 @@
+//
+//  RegistryAPITests.swift
+//  ProvidentTests
+//
+//  Created by Ceri Hughes on 19/04/2020.
+//  Copyright © 2020 Ceri Hughes. All rights reserved.
+//
+
+import Provident // To test the API we must NOT use @testable
+import XCTest
+
+class RegistryAPITests: XCTestCase {
+    private var registry: Registry<String, Void>!
+    private var registrar: Registrar<String, Void>!
+
+    override func setUp() {
+        super.setUp()
+
+        registry = Registry()
+        registrar = Registrar(registry: registry)
+    }
+
+    override func tearDown() {
+        registry = nil
+        registrar = nil
+
+        super.tearDown()
+    }
+
+    func testResolveFunctions() {
+        let serviceProviderFunctions: [Registrar<String, Void>.ServiceProviderFunction] = [
+            TestServiceProvider.init(context:)
+        ]
+
+        let viewControllerProviderFunctions: [Registrar<String, Void>.ViewControllerProviderFunction] = [
+            TestViewControllerProvider.init
+        ]
+
+        XCTAssertNil(registry.createViewController(from: "Test"))
+        XCTAssertNil(registry.createViewController(from: "Test", context: ()))
+
+        registrar.resolve(serviceProviderFunctions: serviceProviderFunctions, viewControllerProviderFunctions: viewControllerProviderFunctions)
+
+        XCTAssertNotNil(registry.createViewController(from: "Test"))
+        XCTAssertNotNil(registry.createViewController(from: "Test", context: ()))
+    }
+
+    func testResolveResolver() {
+        let serviceProviderFunctions: [Registrar<String, Void>.ServiceProviderFunction] = [
+            TestServiceProvider.init(context:)
+        ]
+
+        let viewControllerProviderFunctions: [Registrar<String, Void>.ViewControllerProviderFunction] = [
+            TestViewControllerProvider.init
+        ]
+
+        XCTAssertNil(registry.createViewController(from: "Test"))
+        XCTAssertNil(registry.createViewController(from: "Test", context: ()))
+
+        let resolver = TestResolver(testServiceProviderFunctions: serviceProviderFunctions,
+                                    testViewControllerProviderFunctions: viewControllerProviderFunctions)
+        registrar.resolve(resolver: resolver)
+
+        XCTAssertNotNil(registry.createViewController(from: "Test"))
+        XCTAssertNotNil(registry.createViewController(from: "Test", context: ()))
+    }
+}

--- a/Tests/Registry/RegistryTests.swift
+++ b/Tests/Registry/RegistryTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import UIKit
 
 @testable import Provident
 

--- a/Tests/Registry/RegistryTests.swift
+++ b/Tests/Registry/RegistryTests.swift
@@ -153,9 +153,7 @@ class RegistryTests: XCTestCase {
                 title = "function \(limit)"
             }
 
-            let vc = UIViewController()
-            vc.title = title
-            return vc
+            return UIViewController(title: title)
         }
     }
 }

--- a/Tests/Registry/RegistryTests.swift
+++ b/Tests/Registry/RegistryTests.swift
@@ -11,7 +11,7 @@ import XCTest
 @testable import Provident
 
 class RegistryTests: XCTestCase {
-    private var registry: Registry<Int, String>!
+    private var registry: Registry<Int, String?>!
 
     override func setUp() {
         super.setUp()
@@ -42,7 +42,7 @@ class RegistryTests: XCTestCase {
     }
 
     func testRegisterFunctionWithContext() {
-        let uuid = registry.add(registryFunction: createFunctionWithContext(limit: 10))
+        let uuid = registry.add(registryFunction: createFunction(limit: 10))
         XCTAssertNotNil(registry.createViewController(from: 1, context: "Things"))
 
         registry.removeRegistryFunction(uuid: uuid)
@@ -50,8 +50,8 @@ class RegistryTests: XCTestCase {
     }
 
     func testRegisterFunctionWithContext_withoutProvidingContext() {
-        let uuid = registry.add(registryFunction: createFunctionWithContext(limit: 10))
-        XCTAssertNil(registry.createViewController(from: 1))
+        let uuid = registry.add(registryFunction: createFunction(limit: 10))
+        XCTAssertNotNil(registry.createViewController(from: 1))
 
         registry.removeRegistryFunction(uuid: uuid)
         XCTAssertNil(registry.createViewController(from: 1))
@@ -73,12 +73,12 @@ class RegistryTests: XCTestCase {
     }
 
     func testRegisterFunctionWithContext_oneIsValid() {
-        let uuid1 = registry.add(registryFunction: createFunctionWithContext(limit: 0))
-        let uuid2 = registry.add(registryFunction: createFunctionWithContext(limit: 1))
+        let uuid1 = registry.add(registryFunction: createFunction(limit: 0))
+        let uuid2 = registry.add(registryFunction: createFunction(limit: 1))
 
         let vc = registry.createViewController(from: 1, context: "Things")
         XCTAssertNotNil(vc)
-        XCTAssertEqual(vc!.title, "functionWithContext 1")
+        XCTAssertEqual(vc!.title, "functionWithContext 1:Things")
 
         registry.removeRegistryFunction(uuid: uuid2)
         XCTAssertNil(registry.createViewController(from: 1, context: "Things"))
@@ -103,12 +103,12 @@ class RegistryTests: XCTestCase {
     }
 
     func testRegisterFunctionsWithContext_allValid_usesFirstRegistered() {
-        let uuid1 = registry.add(registryFunction: createFunctionWithContext(limit: 0))
-        let uuid2 = registry.add(registryFunction: createFunctionWithContext(limit: 1))
+        let uuid1 = registry.add(registryFunction: createFunction(limit: 0))
+        let uuid2 = registry.add(registryFunction: createFunction(limit: 1))
 
         let vc = registry.createViewController(from: 0, context: "Things")
         XCTAssertNotNil(vc)
-        XCTAssertEqual(vc!.title, "functionWithContext 0")
+        XCTAssertEqual(vc!.title, "functionWithContext 0:Things")
 
         registry.removeRegistryFunction(uuid: uuid2)
         XCTAssertNotNil(registry.createViewController(from: 0, context: "Things"))
@@ -118,128 +118,44 @@ class RegistryTests: XCTestCase {
     }
 
     func testRegisterMixedFunctions_functionsWithContextsReturnFirst() {
-        let uuid1 = registry.add(registryFunction: createFunctionWithContext(limit: 0))
-        let uuid2 = registry.add(registryFunction: createFunction(limit: 0))
+        let uuid = registry.add(registryFunction: createFunction(limit: 0))
 
-        var vc = registry.createViewController(from: 0, context: "Things")
-        XCTAssertEqual(vc!.title, "functionWithContext 0")
-        registry.removeRegistryFunction(uuid: uuid1)
-
-        vc = registry.createViewController(from: 0, context: "Things")
-        XCTAssertEqual(vc!.title, "function 0")
-        registry.removeRegistryFunction(uuid: uuid2)
+        let vc = registry.createViewController(from: 0, context: "Things")
+        XCTAssertEqual(vc!.title, "functionWithContext 0:Things")
+        registry.removeRegistryFunction(uuid: uuid)
     }
 
     func testRegisterMixedFunctions_allValid_usesFirstRegistered() {
-        let uuid1 = registry.add(registryFunction: createFunctionWithContext(limit: 0))
-        let uuid2 = registry.add(registryFunction: createFunctionWithContext(limit: 1))
-        let uuid3 = registry.add(registryFunction: createFunction(limit: 0))
-        let uuid4 = registry.add(registryFunction: createFunction(limit: 1))
+        let uuid1 = registry.add(registryFunction: createFunction(limit: 0))
+        let uuid2 = registry.add(registryFunction: createFunction(limit: 1))
 
         var vc = registry.createViewController(from: 0, context: "Things")
-        XCTAssertEqual(vc!.title, "functionWithContext 0")
+        XCTAssertEqual(vc!.title, "functionWithContext 0:Things")
         registry.removeRegistryFunction(uuid: uuid1)
 
         vc = registry.createViewController(from: 0, context: "Things")
-        XCTAssertEqual(vc!.title, "functionWithContext 1")
-        registry.removeRegistryFunction(uuid: uuid2)
-
-        vc = registry.createViewController(from: 0, context: "Things")
-        XCTAssertEqual(vc!.title, "function 0")
-        registry.removeRegistryFunction(uuid: uuid3)
-
-        vc = registry.createViewController(from: 0, context: "Things")
-        XCTAssertEqual(vc!.title, "function 1")
-        registry.removeRegistryFunction(uuid: uuid4)
-    }
-
-    func testRegistryDelegateHeldWeakly() {
-        var delegate: RegistryTests_RegistryDelegate? = RegistryTests_RegistryDelegate()
-        registry.delegate = delegate
-
-        XCTAssertNotNil(registry.delegate)
-
-        delegate = nil
-
-        XCTAssertNil(registry.delegate)
-    }
-
-    func testRegistryDelegate() {
-        let delegate = RegistryTests_RegistryDelegate()
-        registry.delegate = delegate
-
-        let uuid1 = registry.add(registryFunction: createFunction(limit: 10))
-        let uuid2 = registry.add(registryFunction: createFunctionWithContext(limit: 10))
-
-        let vc1 = registry.createViewController(from: 1)
-        let vc2 = registry.createViewController(from: 1, context: "Things")
-        let vc3 = registry.createViewController(from: 11)
-        let vc4 = registry.createViewController(from: 11, context: "Things")
-        XCTAssertNotNil(vc1)
-        XCTAssertNotNil(vc2)
-        XCTAssertNil(vc3)
-        XCTAssertNil(vc4)
-
-        XCTAssertEqual(delegate.successfulCreations.count, 2)
-
-        XCTAssertEqual(delegate.successfulCreations[0].0, vc1)
-        XCTAssertEqual(delegate.successfulCreations[0].1, 1)
-        XCTAssertNil(delegate.successfulCreations[0].2)
-
-        XCTAssertEqual(delegate.successfulCreations[1].0, vc2)
-        XCTAssertEqual(delegate.successfulCreations[1].1, 1)
-        XCTAssertEqual(delegate.successfulCreations[1].2, "Things")
-
-        XCTAssertEqual(delegate.unsuccessfulCreations.count, 2)
-
-        XCTAssertEqual(delegate.unsuccessfulCreations[0].0, 11)
-        XCTAssertNil(delegate.unsuccessfulCreations[0].1)
-
-        XCTAssertEqual(delegate.unsuccessfulCreations[1].0, 11)
-        XCTAssertEqual(delegate.unsuccessfulCreations[1].1, "Things")
-
-        registry.removeRegistryFunction(uuid: uuid1)
+        XCTAssertEqual(vc!.title, "functionWithContext 1:Things")
         registry.removeRegistryFunction(uuid: uuid2)
     }
-}
 
-private extension RegistryTests {
     // MARK: - Test functions
 
-    func createFunction(limit: Int) -> (Int) -> UIViewController? {
-        return { token in
+    private func createFunction(limit: Int) -> (Int, String?) -> UIViewController? {
+        return { token, context in
             guard token <= limit else {
                 return nil
             }
 
-            let vc = UIViewController()
-            vc.title = "function \(limit)"
-            return vc
-        }
-    }
-
-    func createFunctionWithContext(limit: Int) -> (Int, String) -> UIViewController? {
-        return { token, _ in
-            guard token <= limit else {
-                return nil
+            let title: String
+            if let context = context {
+                title = "functionWithContext \(limit):\(context)"
+            } else {
+                title = "function \(limit)"
             }
 
             let vc = UIViewController()
-            vc.title = "functionWithContext \(limit)"
+            vc.title = title
             return vc
         }
-    }
-}
-
-private class RegistryTests_RegistryDelegate: RegistryDelegate {
-    var successfulCreations = [(UIViewController, Int, String?)]()
-    var unsuccessfulCreations = [(Int, String?)]()
-
-    func registryDidCreateViewController(_ viewController: UIViewController, from token: Any, context: Any?) {
-        successfulCreations.append((viewController, token as! Int, context as! String?))
-    }
-
-    func registryDidNotCreateViewControllerFrom(_ token: Any, context: Any?) {
-        unsuccessfulCreations.append((token as! Int, context as! String?))
     }
 }

--- a/Tests/Registry/RegistryTests.swift
+++ b/Tests/Registry/RegistryTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2019 Ceri Hughes. All rights reserved.
 //
 
-import XCTest
 import UIKit
+import XCTest
 
 @testable import Provident
 
@@ -27,116 +27,74 @@ class RegistryTests: XCTestCase {
     }
 
     func testRegisterFunction() {
-        let uuid = registry.add(registryFunction: createFunction(limit: 10))
+        registry.add(registryFunction: createFunction(limit: 10))
         XCTAssertNotNil(registry.createViewController(from: 1))
-
-        registry.removeRegistryFunction(uuid: uuid)
-        XCTAssertNil(registry.createViewController(from: 1))
     }
 
     func testRegisterFunction_providingContext() {
-        let uuid = registry.add(registryFunction: createFunction(limit: 10))
+        registry.add(registryFunction: createFunction(limit: 10))
         XCTAssertNotNil(registry.createViewController(from: 1, context: "Things"))
-
-        registry.removeRegistryFunction(uuid: uuid)
-        XCTAssertNil(registry.createViewController(from: 1, context: "Things"))
     }
 
     func testRegisterFunctionWithContext() {
-        let uuid = registry.add(registryFunction: createFunction(limit: 10))
+        registry.add(registryFunction: createFunction(limit: 10))
         XCTAssertNotNil(registry.createViewController(from: 1, context: "Things"))
-
-        registry.removeRegistryFunction(uuid: uuid)
-        XCTAssertNil(registry.createViewController(from: 1, context: "Things"))
     }
 
     func testRegisterFunctionWithContext_withoutProvidingContext() {
-        let uuid = registry.add(registryFunction: createFunction(limit: 10))
+        registry.add(registryFunction: createFunction(limit: 10))
         XCTAssertNotNil(registry.createViewController(from: 1))
-
-        registry.removeRegistryFunction(uuid: uuid)
-        XCTAssertNil(registry.createViewController(from: 1))
     }
 
     func testRegisterFunctions_oneIsValid() {
-        let uuid1 = registry.add(registryFunction: createFunction(limit: 0))
-        let uuid2 = registry.add(registryFunction: createFunction(limit: 1))
+        registry.add(registryFunction: createFunction(limit: 0))
+        registry.add(registryFunction: createFunction(limit: 1))
 
         let vc = registry.createViewController(from: 1)
         XCTAssertNotNil(vc)
         XCTAssertEqual(vc!.title, "function 1")
-
-        registry.removeRegistryFunction(uuid: uuid2)
-        XCTAssertNil(registry.createViewController(from: 1))
-
-        registry.removeRegistryFunction(uuid: uuid1)
-        XCTAssertNil(registry.createViewController(from: 1))
     }
 
     func testRegisterFunctionWithContext_oneIsValid() {
-        let uuid1 = registry.add(registryFunction: createFunction(limit: 0))
-        let uuid2 = registry.add(registryFunction: createFunction(limit: 1))
+        registry.add(registryFunction: createFunction(limit: 0))
+        registry.add(registryFunction: createFunction(limit: 1))
 
         let vc = registry.createViewController(from: 1, context: "Things")
         XCTAssertNotNil(vc)
         XCTAssertEqual(vc!.title, "functionWithContext 1:Things")
-
-        registry.removeRegistryFunction(uuid: uuid2)
-        XCTAssertNil(registry.createViewController(from: 1, context: "Things"))
-
-        registry.removeRegistryFunction(uuid: uuid1)
-        XCTAssertNil(registry.createViewController(from: 1, context: "Things"))
     }
 
     func testRegisterFunctions_allValid_usesFirstRegistered() {
-        let uuid1 = registry.add(registryFunction: createFunction(limit: 0))
-        let uuid2 = registry.add(registryFunction: createFunction(limit: 1))
+        registry.add(registryFunction: createFunction(limit: 0))
+        registry.add(registryFunction: createFunction(limit: 1))
 
         let vc = registry.createViewController(from: 0)
         XCTAssertNotNil(vc)
         XCTAssertEqual(vc!.title, "function 0")
-
-        registry.removeRegistryFunction(uuid: uuid2)
-        XCTAssertNotNil(registry.createViewController(from: 0))
-
-        registry.removeRegistryFunction(uuid: uuid1)
-        XCTAssertNil(registry.createViewController(from: 0))
     }
 
     func testRegisterFunctionsWithContext_allValid_usesFirstRegistered() {
-        let uuid1 = registry.add(registryFunction: createFunction(limit: 0))
-        let uuid2 = registry.add(registryFunction: createFunction(limit: 1))
+        registry.add(registryFunction: createFunction(limit: 0))
+        registry.add(registryFunction: createFunction(limit: 1))
 
         let vc = registry.createViewController(from: 0, context: "Things")
         XCTAssertNotNil(vc)
         XCTAssertEqual(vc!.title, "functionWithContext 0:Things")
-
-        registry.removeRegistryFunction(uuid: uuid2)
-        XCTAssertNotNil(registry.createViewController(from: 0, context: "Things"))
-
-        registry.removeRegistryFunction(uuid: uuid1)
-        XCTAssertNil(registry.createViewController(from: 0, context: "Things"))
     }
 
     func testRegisterMixedFunctions_functionsWithContextsReturnFirst() {
-        let uuid = registry.add(registryFunction: createFunction(limit: 0))
+        registry.add(registryFunction: createFunction(limit: 0))
 
         let vc = registry.createViewController(from: 0, context: "Things")
         XCTAssertEqual(vc!.title, "functionWithContext 0:Things")
-        registry.removeRegistryFunction(uuid: uuid)
     }
 
     func testRegisterMixedFunctions_allValid_usesFirstRegistered() {
-        let uuid1 = registry.add(registryFunction: createFunction(limit: 0))
-        let uuid2 = registry.add(registryFunction: createFunction(limit: 1))
+        registry.add(registryFunction: createFunction(limit: 0))
+        registry.add(registryFunction: createFunction(limit: 1))
 
-        var vc = registry.createViewController(from: 0, context: "Things")
+        let vc = registry.createViewController(from: 0, context: "Things")
         XCTAssertEqual(vc!.title, "functionWithContext 0:Things")
-        registry.removeRegistryFunction(uuid: uuid1)
-
-        vc = registry.createViewController(from: 0, context: "Things")
-        XCTAssertEqual(vc!.title, "functionWithContext 1:Things")
-        registry.removeRegistryFunction(uuid: uuid2)
     }
 
     // MARK: - Test functions

--- a/Tests/Registry/RegistryVoidContextTests.swift
+++ b/Tests/Registry/RegistryVoidContextTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 Ceri Hughes. All rights reserved.
 //
 
-import XCTest
 import UIKit
+import XCTest
 
 @testable import Provident
 
@@ -27,41 +27,26 @@ class RegistryVoidContextTests: XCTestCase {
     }
 
     func testRegisterFunction() {
-        let uuid = registry.add(registryFunction: createFunction(limit: 10))
+        registry.add(registryFunction: createFunction(limit: 10))
         XCTAssertNotNil(registry.createViewController(from: 1))
-
-        registry.removeRegistryFunction(uuid: uuid)
-        XCTAssertNil(registry.createViewController(from: 1))
     }
 
     func testRegisterFunctions_oneIsValid() {
-        let uuid1 = registry.add(registryFunction: createFunction(limit: 0))
-        let uuid2 = registry.add(registryFunction: createFunction(limit: 1))
+        registry.add(registryFunction: createFunction(limit: 0))
+        registry.add(registryFunction: createFunction(limit: 1))
 
         let vc = registry.createViewController(from: 1)
         XCTAssertNotNil(vc)
         XCTAssertEqual(vc!.title, "function 1")
-
-        registry.removeRegistryFunction(uuid: uuid2)
-        XCTAssertNil(registry.createViewController(from: 1))
-
-        registry.removeRegistryFunction(uuid: uuid1)
-        XCTAssertNil(registry.createViewController(from: 1))
     }
 
     func testRegisterFunctions_allValid_usesFirstRegistered() {
-        let uuid1 = registry.add(registryFunction: createFunction(limit: 0))
-        let uuid2 = registry.add(registryFunction: createFunction(limit: 1))
+        registry.add(registryFunction: createFunction(limit: 0))
+        registry.add(registryFunction: createFunction(limit: 1))
 
         let vc = registry.createViewController(from: 0)
         XCTAssertNotNil(vc)
         XCTAssertEqual(vc!.title, "function 0")
-
-        registry.removeRegistryFunction(uuid: uuid2)
-        XCTAssertNotNil(registry.createViewController(from: 0))
-
-        registry.removeRegistryFunction(uuid: uuid1)
-        XCTAssertNil(registry.createViewController(from: 0))
     }
 
     // MARK: - Test functions

--- a/Tests/Registry/RegistryVoidContextTests.swift
+++ b/Tests/Registry/RegistryVoidContextTests.swift
@@ -2,7 +2,7 @@
 //  RegistryVoidContextTests.swift
 //  ProvidentTests
 //
-//  Created by Home on 19/04/2020.
+//  Created by Ceri Hughes on 19/04/2020.
 //  Copyright © 2020 Ceri Hughes. All rights reserved.
 //
 
@@ -71,9 +71,7 @@ class RegistryVoidContextTests: XCTestCase {
                 return nil
             }
 
-            let vc = UIViewController()
-            vc.title = "function \(limit)"
-            return vc
+            return UIViewController(title: "function \(limit)")
         }
     }
 }

--- a/Tests/Registry/RegistryVoidContextTests.swift
+++ b/Tests/Registry/RegistryVoidContextTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import UIKit
 
 @testable import Provident
 

--- a/Tests/Registry/RegistryVoidContextTests.swift
+++ b/Tests/Registry/RegistryVoidContextTests.swift
@@ -1,0 +1,79 @@
+//
+//  RegistryVoidContextTests.swift
+//  ProvidentTests
+//
+//  Created by Home on 19/04/2020.
+//  Copyright © 2020 Ceri Hughes. All rights reserved.
+//
+
+import XCTest
+
+@testable import Provident
+
+class RegistryVoidContextTests: XCTestCase {
+    private var registry: Registry<Int, Void>!
+
+    override func setUp() {
+        super.setUp()
+
+        registry = Registry()
+    }
+
+    override func tearDown() {
+        registry = nil
+
+        super.tearDown()
+    }
+
+    func testRegisterFunction() {
+        let uuid = registry.add(registryFunction: createFunction(limit: 10))
+        XCTAssertNotNil(registry.createViewController(from: 1))
+
+        registry.removeRegistryFunction(uuid: uuid)
+        XCTAssertNil(registry.createViewController(from: 1))
+    }
+
+    func testRegisterFunctions_oneIsValid() {
+        let uuid1 = registry.add(registryFunction: createFunction(limit: 0))
+        let uuid2 = registry.add(registryFunction: createFunction(limit: 1))
+
+        let vc = registry.createViewController(from: 1)
+        XCTAssertNotNil(vc)
+        XCTAssertEqual(vc!.title, "function 1")
+
+        registry.removeRegistryFunction(uuid: uuid2)
+        XCTAssertNil(registry.createViewController(from: 1))
+
+        registry.removeRegistryFunction(uuid: uuid1)
+        XCTAssertNil(registry.createViewController(from: 1))
+    }
+
+    func testRegisterFunctions_allValid_usesFirstRegistered() {
+        let uuid1 = registry.add(registryFunction: createFunction(limit: 0))
+        let uuid2 = registry.add(registryFunction: createFunction(limit: 1))
+
+        let vc = registry.createViewController(from: 0)
+        XCTAssertNotNil(vc)
+        XCTAssertEqual(vc!.title, "function 0")
+
+        registry.removeRegistryFunction(uuid: uuid2)
+        XCTAssertNotNil(registry.createViewController(from: 0))
+
+        registry.removeRegistryFunction(uuid: uuid1)
+        XCTAssertNil(registry.createViewController(from: 0))
+    }
+
+    // MARK: - Test functions
+
+    private func createFunction(limit: Int) -> (Int, Void) -> UIViewController? {
+        return { token, _ in
+            guard token <= limit else {
+                return nil
+            }
+
+            let vc = UIViewController()
+            vc.title = "function \(limit)"
+            return vc
+        }
+    }
+}

--- a/Tests/Resolver/TestResolver.swift
+++ b/Tests/Resolver/TestResolver.swift
@@ -10,22 +10,22 @@ import Foundation
 import Provident
 
 class TestResolver: Resolver<String, Void> {
-    private let testViewControllerProviderCreationFunctions: [() -> ViewControllerProvider<String, Void>]
-    private let testServiceProviderCreationFunctions: [(ServiceProviderCreationContext) -> ServiceProvider]
+    private let testServiceProviderFunctions: [Registrar<String, Void>.ServiceProviderFunction]
+    private let testViewControllerProviderFunctions: [Registrar<String, Void>.ViewControllerProviderFunction]
 
-    init(testViewControllerProviderCreationFunctions: [() -> ViewControllerProvider<String, Void>],
-         testServiceProviderCreationFunctions: [(ServiceProviderCreationContext) -> ServiceProvider]) {
-        self.testViewControllerProviderCreationFunctions = testViewControllerProviderCreationFunctions
-        self.testServiceProviderCreationFunctions = testServiceProviderCreationFunctions
+    init(testServiceProviderFunctions: [Registrar<String, Void>.ServiceProviderFunction],
+         testViewControllerProviderFunctions: [Registrar<String, Void>.ViewControllerProviderFunction]) {
+        self.testServiceProviderFunctions = testServiceProviderFunctions
+        self.testViewControllerProviderFunctions = testViewControllerProviderFunctions
 
         super.init()
     }
 
-    override func viewControllerProviderCreationFunctions() -> [() -> ViewControllerProvider<String, Void>] {
-        return testViewControllerProviderCreationFunctions
+    override func serviceProviderFunctions() -> [Registrar<String, Void>.ServiceProviderFunction] {
+        return testServiceProviderFunctions
     }
 
-    override func serviceProviderCreationFunctions() -> [(ServiceProviderCreationContext) -> ServiceProvider] {
-        return testServiceProviderCreationFunctions
+    override func viewControllerProviderFunctions() -> [Registrar<String, Void>.ViewControllerProviderFunction] {
+        return testViewControllerProviderFunctions
     }
 }

--- a/Tests/TestData.swift
+++ b/Tests/TestData.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Ceri Hughes. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 @testable import Provident
 

--- a/Tests/TestData.swift
+++ b/Tests/TestData.swift
@@ -7,21 +7,28 @@
 //
 
 import Foundation
-import Provident
+
+@testable import Provident
 
 class TestViewControllerProvider: ViewControllerProvider<String, Void> {
     var registered = false, unregistered = false
     var capturedServiceProviders: [String: ServiceProvider]?
-    override func register(with _: Registry<String, Void>) {
+    override func register(with registry: Registry<String, Void>) {
+        super.register(with: registry)
         registered = true
     }
 
-    override func unregister(from _: Registry<String, Void>) {
+    override func unregister(from registry: Registry<String, Void>) {
+        super.unregister(from: registry)
         unregistered = true
     }
 
     override func configure(with serviceProviders: [String: ServiceProvider]) {
         capturedServiceProviders = serviceProviders
+    }
+
+    override func createViewController(token: String, context: Void) -> UIViewController? {
+        return UIViewController(title: token)
     }
 }
 

--- a/Tests/TestData.swift
+++ b/Tests/TestData.swift
@@ -10,17 +10,12 @@ import UIKit
 
 @testable import Provident
 
-class TestViewControllerProvider: ViewControllerProvider<String, Void> {
+class TestViewControllerProvider: SingleViewControllerProvider<String, Void> {
     var registered = false, unregistered = false
     var capturedServiceProviders: [String: ServiceProvider]?
     override func register(with registry: Registry<String, Void>) {
         super.register(with: registry)
         registered = true
-    }
-
-    override func unregister(from registry: Registry<String, Void>) {
-        super.unregister(from: registry)
-        unregistered = true
     }
 
     override func configure(with serviceProviders: [String: ServiceProvider]) {

--- a/Tests/UIViewController+Testing.swift
+++ b/Tests/UIViewController+Testing.swift
@@ -1,0 +1,16 @@
+//
+//  UIViewController+Testing.swift
+//  ProvidentTests
+//
+//  Created by Ceri on 19/04/2020.
+//  Copyright © 2020 Ceri Hughes. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+    convenience init(title: String) {
+        self.init()
+        self.title = title
+    }
+}


### PR DESCRIPTION
Simplify the Provident API:

- Remove support for the delegate
- Remove API for "contextless" functions
- Don't support unregistering / removing